### PR TITLE
Fix compatibility issues with Bolt 3.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Hierarchical Routes
 
-> Heh... the term "Hierarchical Routes" actually makes no sense.
-
 A simple way to get hierarchical content to work by using `menu.yml`.
 No assumptions or crazy features. This extensions allows you to do a few things:
 
@@ -27,19 +25,17 @@ existing items.
 - `rules`: apply some sets of content under a (parent) node
   - `type: contenttype`: put all items from a specific contenttype under a node
   - `type: query`: use a `setcontent`-like query to put a whole set under a node
-- `cache`: enable caching and set the cache duration in minutes
 - `settings`: other settings
   - `overwrite-duplicates`: allow duplicates to be overwritten, or not
-  - `rebuild-on-save`: allow cache to be rebuilt on record save/delete
 
 
 ## Cache
 
-By default, caching is enabled. By default (under `rebuild-on-save`), the
-internal hierarchy will be rebuilt on every record's save and delete event.
-However, this is not done after saving config files (`menu.yml` and
-`hierarchicalroutes.twokings.yml`), so clear the cache when editing these, or
-wait until the cache expires.
+Once a menu is built, it will be stored in the configuration folder, by default
+in `app/config/extensions/hierarchicalroutes/`. This is invalidated and rebuilt
+on every save of a record. However, this is not automatically done after saving
+config files (`menu.yml` and `hierarchicalroutes.twokings.yml`) as this might
+require an additional refresh.
 
 
 ## Twig functions

--- a/config/config.yml.dist
+++ b/config/config.yml.dist
@@ -33,16 +33,6 @@ rules:
     #     parent: "entry/1"
 
 
-# Cache
-# -----
-# Enable cache in order to save the generated look-up table for performance.
-# The duration of the cache is in minutes.
-
-cache:
-    enabled: true
-    duration: 10
-
-
 # Settings
 # --------
 # overwrite-duplicates: Whether to overwrite when a duplicate entry has been
@@ -53,17 +43,10 @@ cache:
 #                       sense. There _should_ be no duplicates. This feature
 #                       might change in the future.
 #
-# rebuild-on-save: Rebuild hierarchy after saving or deleting a record. Only
-#                  used when caching is enabled. This is useful if rebuilding
-#                  the hierarchy costs some time. In that case, you might want
-#                  to clear the cache manually and have a longer than default
-#                  cache duration.
-#
 # override-slugs: Allow (slugifized) names in `menu.yml` override the slugs
 #                 defined in the records. Not implemented yet.
 #
 
 settings:
     overwrite-duplicates : true
-    rebuild-on-save      : true
     override-slugs       : false # -- todo: not implemented yet.

--- a/src/Controller/HierarchicalRoutesController.php
+++ b/src/Controller/HierarchicalRoutesController.php
@@ -62,6 +62,7 @@ class HierarchicalRoutesController implements ControllerProviderInterface
      */
     public function recordExactMatch(Application $app, $slug)
     {
+        /** @var \Bolt\Legacy\Content $content */
         $content = $app['storage']->getContent(
             array_search($slug, $app['hierarchicalroutes.service']->getRecordRoutes()),
             ['hydrate' => false]

--- a/src/Controller/Requirement.php
+++ b/src/Controller/Requirement.php
@@ -12,12 +12,22 @@ class Requirement
     /** @var HierarchicalRoutesService $service */
     private $service;
 
+    private $recordRoutes     = [];
+    private $listingRoutes    = [];
+    private $potentialParents = [];
+
     /**
      * @param HierarchicalRoutesService $service
      */
     public function __construct(HierarchicalRoutesService $service)
     {
         $this->service = $service;
+
+        // This call makes sure we got something to work with, when controllers
+        // are connected.
+        $this->recordRoutes     = $this->service->getRecordRoutes();
+        $this->listingRoutes    = $this->service->getListingRoutes();
+        $this->potentialParents = $this->service->getPotentialParents();
     }
 
     /**
@@ -25,7 +35,7 @@ class Requirement
      */
     public function anyRecordRouteConstraint()
     {
-        return $this->createConstraints($this->service->getRecordRoutes());
+        return $this->createConstraints($this->recordRoutes);
     }
 
     /**
@@ -33,7 +43,7 @@ class Requirement
      */
     public function anyListingRouteConstraint()
     {
-        return $this->createConstraints($this->service->getListingRoutes());
+        return $this->createConstraints($this->listingRoutes);
     }
 
     /**
@@ -41,7 +51,7 @@ class Requirement
      */
     public function anyPotentialParentConstraint()
     {
-        return $this->createConstraints($this->service->getPotentialParents());
+        return $this->createConstraints($this->potentialParents);
     }
 
     /**

--- a/src/Listener/KernelEventListener.php
+++ b/src/Listener/KernelEventListener.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Bolt\Extension\TwoKings\HierarchicalRoutes\Listener;
+
+use Bolt\Events\StorageEvent;
+use Bolt\Extension\TwoKings\HierarchicalRoutes\Service\HierarchicalRoutesService;
+use Silex\Application;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Event class to handle events early enough to work, but late enough that db
+ * and config are initialized.
+ *
+ * @author Xiao-Hu Tai <xiao@twokings.nl>
+ */
+class KernelEventListener implements EventSubscriberInterface
+{
+    /** @var HierarchicalRoutesService $service */
+    private $service;
+
+    /**
+     * @param HierarchicalRoutesService $service
+     */
+    public function __construct(HierarchicalRoutesService $service)
+    {
+        $this->service = $service;
+    }
+
+    /**
+     * Kernel request listener callback.
+     *
+     * @param GetResponseEvent $event
+     */
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        $this->service->build();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::REQUEST => ['onKernelRequest', 31],
+        ];
+    }
+}

--- a/src/Listener/StorageEventListener.php
+++ b/src/Listener/StorageEventListener.php
@@ -31,7 +31,7 @@ class StorageEventListener implements EventSubscriberInterface
      */
     public function onPostSave(StorageEvent $event)
     {
-        $service->build(false);
+        $service->rebuild();
     }
 
     /**
@@ -41,7 +41,7 @@ class StorageEventListener implements EventSubscriberInterface
      */
     public function onPostDelete(StorageEvent $event)
     {
-        $service->build(false);
+        $service->rebuild();
     }
 
     /**

--- a/src/Listener/StorageEventListener.php
+++ b/src/Listener/StorageEventListener.php
@@ -13,12 +13,10 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class StorageEventListener implements EventSubscriberInterface
 {
-    /** @var Application Bolt's Application object */
+    /** @var Application $app */
     private $app;
 
     /**
-     * Initiate the listener with Bolt Application instance and extension config.
-     *
      * @param Application $app
      */
     public function __construct(Application $app)
@@ -33,12 +31,7 @@ class StorageEventListener implements EventSubscriberInterface
      */
     public function onPostSave(StorageEvent $event)
     {
-        $config  = $this->app['hierarchicalroutes.config'];
-        $service = $this->app['hierarchicalroutes.service'];
-
-        if ($config->get('cache/enabled', true) && $config->get('settings/rebuild-on-save', true)) {
-            $service->build(false);
-        }
+        $service->build(false);
     }
 
     /**
@@ -48,12 +41,7 @@ class StorageEventListener implements EventSubscriberInterface
      */
     public function onPostDelete(StorageEvent $event)
     {
-        $config  = $this->app['hierarchicalroutes.config'];
-        $service = $this->app['hierarchicalroutes.service'];
-
-        if ($config->get('cache/enabled', true) && $config->get('settings/rebuild-on-save', true)) {
-            $service->build(false);
-        }
+        $service->build(false);
     }
 
     /**

--- a/src/Provider/HierarchicalRoutesProvider.php
+++ b/src/Provider/HierarchicalRoutesProvider.php
@@ -32,7 +32,7 @@ class HierarchicalRoutesProvider implements ServiceProviderInterface
                     $app['config'],
                     $app['storage.lazy'],
                     $app['query'],
-                    $app['cache'],
+                    $app['filesystem'],
                     $app['logger.system']
                 );
             }

--- a/src/Provider/HierarchicalRoutesProvider.php
+++ b/src/Provider/HierarchicalRoutesProvider.php
@@ -30,7 +30,7 @@ class HierarchicalRoutesProvider implements ServiceProviderInterface
                 return new Service\HierarchicalRoutesService(
                     $app['hierarchicalroutes.config'],
                     $app['config'],
-                    $app['storage'],
+                    $app['storage.lazy'],
                     $app['query'],
                     $app['cache'],
                     $app['logger.system']

--- a/src/Provider/HierarchicalRoutesProvider.php
+++ b/src/Provider/HierarchicalRoutesProvider.php
@@ -27,10 +27,16 @@ class HierarchicalRoutesProvider implements ServiceProviderInterface
     {
         $app['hierarchicalroutes.service'] = $app->share(
             function (Application $app) {
+
+                $key = 'storage.lazy';
+                if (version_compare(BoltVersion::forComposer(), '3.3.0', '<')) {
+                    $key = 'storage';
+                }
+
                 return new Service\HierarchicalRoutesService(
                     $app['hierarchicalroutes.config'],
                     $app['config'],
-                    $app['storage.lazy'],
+                    $app[$key],
                     $app['query'],
                     $app['filesystem'],
                     $app['logger.system']

--- a/src/Service/HierarchicalRoutesService.php
+++ b/src/Service/HierarchicalRoutesService.php
@@ -255,7 +255,7 @@ class HierarchicalRoutesService
     {
         $content = false;
         if (isset($item['path']) && $item['path'] != 'homepage') {
-            // /** @var \Bolt\Legacy\Content $content */
+            /** @var \Bolt\Legacy\Content $content */
             $content = $this->storage->getContent($item['path'], ['hydrate' => false]);
         }
 


### PR DESCRIPTION
See #12 

- Bolt 3.3 lazily loads the storage (Bolt 3.2 uses `storage`, Bolt 3.3 uses `storage.lazy`)
- Bolt 3.3 has better Twig runtimes and loaders
- Bolt 3.3 uses `/extensions` instead of `/extend` as a mountpoint for extensions (backend)