### PR TITLE
Change access rights for this extension

### DIFF
--- a/src/HierarchicalRoutesExtension.php
+++ b/src/HierarchicalRoutesExtension.php
@@ -30,7 +30,7 @@ use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 class HierarchicalRoutesExtension extends SimpleExtension
 {
     /** @var string $permission The permission a user needs for interaction with  the back-end */
-    private $permission = 'settings';
+    private $permission = 'extensions';
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
The 'settings' rights is to broad because users need access to 'settings' if they need access to uploaded files.
Setting the right for 'extensions' makes more sense because it is specific for extension configuration